### PR TITLE
Add quick-win workflows and configurable input actions

### DIFF
--- a/app/src/main/java/com/alexdremov/notate/CanvasActivity.kt
+++ b/app/src/main/java/com/alexdremov/notate/CanvasActivity.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.net.http.SslError
 import android.os.Bundle
 import android.view.Gravity
+import android.view.View
 import android.view.ViewGroup
 import android.webkit.SslErrorHandler
 import android.webkit.WebResourceRequest
@@ -452,6 +453,9 @@ class CanvasActivity : AppCompatActivity() {
                         binding.canvasView.getController().addStrokes(strokes)
                     }
                 },
+                onPalmRejectionChanged = { enabled ->
+                    binding.canvasView.setPalmRejectionEnabled(enabled)
+                },
             )
         binding.canvasView.onStrokeStarted = {
             activePenPopup?.dismiss()
@@ -536,6 +540,12 @@ class CanvasActivity : AppCompatActivity() {
 
         binding.canvasView.setCursorView(binding.cursorView)
         binding.minimapView.setup(binding.canvasView)
+        binding.canvasView.setPalmRejectionEnabled(
+            com.alexdremov.notate.data.PreferencesManager.isPalmRejectionEnabled(this),
+        )
+        binding.canvasView.onThreeFingerTap = {
+            viewModel.toggleDistractionFree()
+        }
 
         // ViewModel observation
         lifecycleScope.launch {
@@ -573,6 +583,10 @@ class CanvasActivity : AppCompatActivity() {
                     viewModel.isFixedPageCenterHorizontal.collect { enabled ->
                         binding.canvasView.setFixedPageCenterHorizontal(enabled)
                     }
+                }
+
+                launch {
+                    viewModel.isDistractionFree.collect { setDistractionFree(it) }
                 }
 
                 launch {
@@ -985,6 +999,17 @@ class CanvasActivity : AppCompatActivity() {
     private fun updateDrawingEnabledState() {
         val shouldDisable = sidebarCoordinator.isOpen || isGridOpen || activePenPopup != null
         viewModel.setDrawingEnabled(!shouldDisable)
+    }
+
+    private fun setDistractionFree(enabled: Boolean) {
+        val vis = if (enabled) View.GONE else View.VISIBLE
+        binding.toolbarContainer.visibility = vis
+        binding.minimapView.visibility = vis
+        if (enabled) {
+            sidebarCoordinator.close()
+        }
+        // Recompute stylus exclusion so the hidden toolbar stops reserving area.
+        updateExclusionRects()
     }
 
     private fun updateExclusionRects() {

--- a/app/src/main/java/com/alexdremov/notate/CanvasActivity.kt
+++ b/app/src/main/java/com/alexdremov/notate/CanvasActivity.kt
@@ -456,6 +456,12 @@ class CanvasActivity : AppCompatActivity() {
                 onPalmRejectionChanged = { enabled ->
                     binding.canvasView.setPalmRejectionEnabled(enabled)
                 },
+                onTwoFingerTapActionChange = { action ->
+                    binding.canvasView.setTwoFingerTapAction(action)
+                },
+                onStylusButtonActionChange = { action ->
+                    binding.canvasView.setStylusButtonAction(action)
+                },
             )
         binding.canvasView.onStrokeStarted = {
             activePenPopup?.dismiss()
@@ -546,6 +552,12 @@ class CanvasActivity : AppCompatActivity() {
         binding.canvasView.onThreeFingerTap = {
             viewModel.toggleDistractionFree()
         }
+        binding.canvasView.setTwoFingerTapAction(
+            com.alexdremov.notate.data.PreferencesManager.getTwoFingerTapAction(this),
+        )
+        binding.canvasView.setStylusButtonAction(
+            com.alexdremov.notate.data.PreferencesManager.getStylusButtonAction(this),
+        )
 
         // ViewModel observation
         lifecycleScope.launch {

--- a/app/src/main/java/com/alexdremov/notate/MainActivity.kt
+++ b/app/src/main/java/com/alexdremov/notate/MainActivity.kt
@@ -27,7 +27,10 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import com.alexdremov.notate.CanvasActivity
+import androidx.lifecycle.lifecycleScope
 import com.alexdremov.notate.data.CanvasItem
+import com.alexdremov.notate.data.DailyNotesManager
+import com.alexdremov.notate.data.PreferencesManager
 import com.alexdremov.notate.data.ProjectItem
 import com.alexdremov.notate.data.RemoteStorageType
 import com.alexdremov.notate.data.SortOption
@@ -42,6 +45,10 @@ import kotlinx.coroutines.launch
 class MainActivity : ComponentActivity() {
     private val viewModel: HomeViewModel by viewModels()
 
+    companion object {
+        private var didAutoOpenDaily = false
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -50,6 +57,23 @@ class MainActivity : ComponentActivity() {
 
         // Handle incoming intent (e.g. from File Manager)
         handleIntent(intent)
+
+        if (savedInstanceState == null &&
+            !didAutoOpenDaily &&
+            PreferencesManager.isOpenDailyOnStartEnabled(this)
+        ) {
+            didAutoOpenDaily = true
+            lifecycleScope.launch {
+                val path = DailyNotesManager.openOrCreateTodayNote(this@MainActivity)
+                if (path != null) {
+                    startActivity(
+                        Intent(this@MainActivity, CanvasActivity::class.java).apply {
+                            putExtra("CANVAS_PATH", path)
+                        },
+                    )
+                }
+            }
+        }
 
         setContent {
             NotateTheme {
@@ -115,8 +139,11 @@ fun MainScreen(
     val selectedTag by viewModel.selectedTag.collectAsState()
     val sortOption by viewModel.sortOption.collectAsState()
     val savingPaths by viewModel.savingPaths.collectAsState()
+    val favorites by viewModel.favorites.collectAsState()
+    val recents by viewModel.recents.collectAsState()
 
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     val lifecycleOwner = LocalLifecycleOwner.current
     val activity = androidx.activity.compose.LocalActivity.current as? ComponentActivity
@@ -213,6 +240,20 @@ fun MainScreen(
                 onAddProject = { showNameDialog = DialogType.ADD_PROJECT },
                 onManageTags = { showNameDialog = DialogType.MANAGE_TAGS },
                 onSettingsClick = { showSettingsDialog = true },
+                onTodayClick = {
+                    scope.launch {
+                        val path = DailyNotesManager.openOrCreateTodayNote(context)
+                        if (path != null) {
+                            context.startActivity(
+                                Intent(context, CanvasActivity::class.java).apply {
+                                    putExtra("CANVAS_PATH", path)
+                                },
+                            )
+                        } else {
+                            snackbarHostState.showSnackbar("Add a project first to use Daily Notes")
+                        }
+                    }
+                },
             )
         }
 
@@ -320,6 +361,7 @@ fun MainScreen(
                                     if (isPickerMode && onFilePicked != null) {
                                         onFilePicked(item)
                                     } else {
+                                        PreferencesManager.addRecent(context, item.uuid ?: item.path)
                                         val intent =
                                             Intent(context, CanvasActivity::class.java).apply {
                                                 putExtra("CANVAS_PATH", item.path)
@@ -333,6 +375,9 @@ fun MainScreen(
                         onItemRename = { item, newName -> if (!isPickerMode) viewModel.renameItem(item, newName) },
                         onItemDuplicate = { item -> if (!isPickerMode) viewModel.duplicateItem(item) },
                         onSetFileTags = { item, newTags -> if (!isPickerMode) viewModel.setFileTags(item, newTags) },
+                        favorites = favorites,
+                        recents = recents,
+                        onToggleFavorite = { if (!isPickerMode) viewModel.toggleFavorite(it) },
                     )
                 }
 

--- a/app/src/main/java/com/alexdremov/notate/data/DailyNotesManager.kt
+++ b/app/src/main/java/com/alexdremov/notate/data/DailyNotesManager.kt
@@ -1,0 +1,74 @@
+package com.alexdremov.notate.data
+
+import android.content.Context
+import com.alexdremov.notate.util.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Finds or creates a "daily note" (a canvas named for the current date) inside a reserved
+ * "Daily Notes" subfolder of the first configured project. v1 simplification: host = first project.
+ */
+object DailyNotesManager {
+    const val DAILY_NOTES_FOLDER = "Daily Notes"
+
+    /** Sanitizer-stable date name (no punctuation, so StorageUtils.getSafeFileName keeps it). */
+    fun todayNoteName(now: Date = Date()): String = SimpleDateFormat("MMM d yyyy", Locale.US).format(now)
+
+    /**
+     * Returns the path of today's note in the first project, creating folder/note if needed.
+     * Returns null if no project is configured or on failure.
+     */
+    suspend fun openOrCreateTodayNote(context: Context): String? =
+        withContext(Dispatchers.IO) {
+            val project =
+                PreferencesManager.getProjects(context).firstOrNull() ?: run {
+                    Logger.w("DailyNotes", "No project configured for daily notes")
+                    return@withContext null
+                }
+
+            val repo = ProjectRepository(context, project.uri)
+            val todayName = todayNoteName()
+
+            try {
+                var folderPath = findFolderPath(repo, DAILY_NOTES_FOLDER)
+                if (folderPath == null) {
+                    repo.createProject(DAILY_NOTES_FOLDER, null)
+                    folderPath = findFolderPath(repo, DAILY_NOTES_FOLDER)
+                }
+                if (folderPath == null) {
+                    Logger.e("DailyNotes", "Failed to create Daily Notes folder", showToUser = true)
+                    return@withContext null
+                }
+
+                findNotePath(repo, folderPath, todayName)?.let { return@withContext it }
+
+                val created =
+                    repo.createCanvas(
+                        todayName,
+                        folderPath,
+                        CanvasType.INFINITE,
+                        0f,
+                        0f,
+                    )
+                created ?: findNotePath(repo, folderPath, todayName)
+            } catch (e: Exception) {
+                Logger.e("DailyNotes", "Failed to open or create today's note", e, showToUser = true)
+                null
+            }
+        }
+
+    private fun findFolderPath(
+        repo: ProjectRepository,
+        name: String,
+    ): String? = repo.getItems(null).firstOrNull { it is ProjectItem && it.name == name }?.path
+
+    private fun findNotePath(
+        repo: ProjectRepository,
+        folderPath: String,
+        noteName: String,
+    ): String? = repo.getItems(folderPath).firstOrNull { it is CanvasItem && it.name == noteName }?.path
+}

--- a/app/src/main/java/com/alexdremov/notate/data/PreferencesManager.kt
+++ b/app/src/main/java/com/alexdremov/notate/data/PreferencesManager.kt
@@ -49,6 +49,12 @@ object PreferencesManager {
     private const val KEY_TAGS = "defined_tags"
     private const val KEY_SORT_OPTION = "browser_sort_option"
     private const val KEY_SCRIBBLE_TO_ERASE = "scribble_to_erase"
+    private const val KEY_PALM_REJECTION = "palm_rejection_enabled"
+    private const val KEY_DISTRACTION_FREE = "distraction_free_enabled"
+    private const val KEY_OPEN_DAILY_ON_START = "open_daily_on_start"
+    private const val KEY_FAVORITES = "favorite_notes"
+    private const val KEY_RECENTS = "recent_notes"
+    private const val MAX_RECENTS = 12
     private const val KEY_SHAPE_PERFECTION_ENABLED = "shape_perfection_enabled"
     private const val KEY_SHAPE_PERFECTION_DELAY = "shape_perfection_delay"
     private const val KEY_ANGLE_SNAPPING = "angle_snapping_enabled"
@@ -189,6 +195,68 @@ object PreferencesManager {
         enabled: Boolean,
     ) {
         getPrefs(context).edit().putBoolean(KEY_SCRIBBLE_TO_ERASE, enabled).apply()
+    }
+
+    fun isPalmRejectionEnabled(context: Context): Boolean = getPrefs(context).getBoolean(KEY_PALM_REJECTION, false)
+
+    fun setPalmRejectionEnabled(
+        context: Context,
+        enabled: Boolean,
+    ) {
+        getPrefs(context).edit().putBoolean(KEY_PALM_REJECTION, enabled).apply()
+    }
+
+    fun isDistractionFreeEnabled(context: Context): Boolean = getPrefs(context).getBoolean(KEY_DISTRACTION_FREE, false)
+
+    fun setDistractionFreeEnabled(
+        context: Context,
+        enabled: Boolean,
+    ) {
+        getPrefs(context).edit().putBoolean(KEY_DISTRACTION_FREE, enabled).apply()
+    }
+
+    fun isOpenDailyOnStartEnabled(context: Context): Boolean = getPrefs(context).getBoolean(KEY_OPEN_DAILY_ON_START, false)
+
+    fun setOpenDailyOnStartEnabled(
+        context: Context,
+        enabled: Boolean,
+    ) {
+        getPrefs(context).edit().putBoolean(KEY_OPEN_DAILY_ON_START, enabled).apply()
+    }
+
+    fun getFavorites(context: Context): Set<String> = getPrefs(context).getStringSet(KEY_FAVORITES, emptySet())?.toSet() ?: emptySet()
+
+    fun isFavorite(
+        context: Context,
+        key: String,
+    ): Boolean = getFavorites(context).contains(key)
+
+    fun setFavorite(
+        context: Context,
+        key: String,
+        favorite: Boolean,
+    ) {
+        val updated = HashSet(getFavorites(context))
+        if (favorite) updated.add(key) else updated.remove(key)
+        getPrefs(context).edit().putStringSet(KEY_FAVORITES, updated).apply()
+    }
+
+    fun getRecents(context: Context): List<String> {
+        val data = getPrefs(context).getString(KEY_RECENTS, null)
+        if (data.isNullOrEmpty()) return emptyList()
+        return data.split("\n").filter { it.isNotEmpty() }
+    }
+
+    fun addRecent(
+        context: Context,
+        key: String,
+    ) {
+        if (key.isEmpty()) return
+        val current = getRecents(context).toMutableList()
+        current.remove(key)
+        current.add(0, key)
+        val capped = current.take(MAX_RECENTS)
+        getPrefs(context).edit().putString(KEY_RECENTS, capped.joinToString("\n")).apply()
     }
 
     fun isCollapsibleToolbarEnabled(context: Context): Boolean = getPrefs(context).getBoolean(KEY_COLLAPSIBLE_TOOLBAR, false)

--- a/app/src/main/java/com/alexdremov/notate/data/PreferencesManager.kt
+++ b/app/src/main/java/com/alexdremov/notate/data/PreferencesManager.kt
@@ -6,8 +6,10 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.util.Base64
 import com.alexdremov.notate.model.PenTool
+import com.alexdremov.notate.model.StylusButtonAction
 import com.alexdremov.notate.model.Tag
 import com.alexdremov.notate.model.ToolbarItem
+import com.alexdremov.notate.model.TwoFingerTapAction
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.decodeFromString
@@ -65,6 +67,8 @@ object PreferencesManager {
     private const val KEY_PDF_EXPORT_SCALE = "pdf_export_scale"
     private const val KEY_SYNC_PDF_TYPE = "sync_pdf_type"
     private const val KEY_FIXED_PAGE_CENTER_HORIZONTAL = "fixed_page_center_horizontal"
+    private const val KEY_TWO_FINGER_TAP_ACTION = "two_finger_tap_action"
+    private const val KEY_STYLUS_BUTTON_ACTION = "stylus_button_action"
 
     // Debug Preferences
     private const val KEY_DEBUG_USE_SIMPLE_RENDERER = "debug_use_simple_renderer"
@@ -94,6 +98,38 @@ object PreferencesManager {
         option: SortOption,
     ) {
         getPrefs(context).edit().putString(KEY_SORT_OPTION, option.name).apply()
+    }
+
+    fun getTwoFingerTapAction(context: Context): TwoFingerTapAction {
+        val name = getPrefs(context).getString(KEY_TWO_FINGER_TAP_ACTION, TwoFingerTapAction.UNDO.name)
+        return try {
+            TwoFingerTapAction.valueOf(name ?: TwoFingerTapAction.UNDO.name)
+        } catch (e: Exception) {
+            TwoFingerTapAction.UNDO
+        }
+    }
+
+    fun setTwoFingerTapAction(
+        context: Context,
+        action: TwoFingerTapAction,
+    ) {
+        getPrefs(context).edit().putString(KEY_TWO_FINGER_TAP_ACTION, action.name).apply()
+    }
+
+    fun getStylusButtonAction(context: Context): StylusButtonAction {
+        val name = getPrefs(context).getString(KEY_STYLUS_BUTTON_ACTION, StylusButtonAction.TEMPORARY_ERASER.name)
+        return try {
+            StylusButtonAction.valueOf(name ?: StylusButtonAction.TEMPORARY_ERASER.name)
+        } catch (e: Exception) {
+            StylusButtonAction.TEMPORARY_ERASER
+        }
+    }
+
+    fun setStylusButtonAction(
+        context: Context,
+        action: StylusButtonAction,
+    ) {
+        getPrefs(context).edit().putString(KEY_STYLUS_BUTTON_ACTION, action.name).apply()
     }
 
     fun getPdfExportScale(context: Context): Float = getPrefs(context).getFloat(KEY_PDF_EXPORT_SCALE, 2.0f)

--- a/app/src/main/java/com/alexdremov/notate/model/InputAction.kt
+++ b/app/src/main/java/com/alexdremov/notate/model/InputAction.kt
@@ -1,0 +1,13 @@
+package com.alexdremov.notate.model
+
+enum class TwoFingerTapAction {
+    UNDO,
+    REDO,
+    PASTE,
+    NONE,
+}
+
+enum class StylusButtonAction {
+    TEMPORARY_ERASER,
+    NONE,
+}

--- a/app/src/main/java/com/alexdremov/notate/ui/OnyxCanvasView.kt
+++ b/app/src/main/java/com/alexdremov/notate/ui/OnyxCanvasView.kt
@@ -17,6 +17,7 @@ import android.view.SurfaceView
 import com.alexdremov.notate.config.CanvasConfig
 import com.alexdremov.notate.data.CanvasData
 import com.alexdremov.notate.data.CanvasType
+import com.alexdremov.notate.data.PreferencesManager
 import com.alexdremov.notate.model.InfiniteCanvasModel
 import com.alexdremov.notate.model.PenTool
 import com.alexdremov.notate.model.Stroke
@@ -114,10 +115,19 @@ class OnyxCanvasView
         private var twoFingerPointerId1 = -1
         private var twoFingerPointerId2 = -1
 
+        // Three-Finger Tap Detection (Distraction-free toggle)
+        private var threeFingerTapDownTime = 0L
+        private var isThreeFingerTapCheck = false
+        private val threeFingerStartPts = Array(3) { floatArrayOf(0f, 0f) }
+        private val threeFingerPointerIds = intArrayOf(-1, -1, -1)
+
         private var lastStrokeEndTime = 0L
 
         private var currentTool: PenTool = PenTool.defaultPens()[0]
         private var isReadOnly = false
+
+        @Volatile
+        private var palmRejectionEnabled: Boolean = PreferencesManager.isPalmRejectionEnabled(context)
 
         private val exclusionRects = ArrayList<Rect>()
 
@@ -134,6 +144,8 @@ class OnyxCanvasView
         var onBrowseFiles: ((onResult: (name: String, uuid: String) -> Unit) -> Unit)? = null
         var onSelectFile: ((onResult: (name: String, path: String) -> Unit) -> Unit)? = null
         var onLinkActivated: ((com.alexdremov.notate.model.LinkItem) -> Unit)? = null
+
+        var onThreeFingerTap: (() -> Unit)? = null
 
         private var contextMenu: com.alexdremov.notate.ui.dialog.CanvasContextMenu? = null
         private lateinit var gestureDetector: android.view.GestureDetector
@@ -401,7 +413,14 @@ class OnyxCanvasView
             val isStylus = event.getToolType(0) == MotionEvent.TOOL_TYPE_STYLUS
             if (isStylus) return false // Handled by RawInputCallback
 
+            if (palmRejectionEnabled) return true // Palm rejection: ignore finger input (stylus draws via RawInputCallback)
+
             if (!isReadOnly) detectTwoFingerTap(event)
+
+            if (!isReadOnly) detectThreeFingerTap(event)
+
+            // Reserve 3+ finger gestures for the distraction-free toggle (no pan/zoom/select).
+            if (!isReadOnly && event.pointerCount >= 3) return true
 
             // 1. Gesture Detector (Long Press, Tap)
             if (gestureDetector.onTouchEvent(event)) {
@@ -493,6 +512,53 @@ class OnyxCanvasView
             x2: Float,
             y2: Float,
         ) = (x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2)
+
+        fun setPalmRejectionEnabled(enabled: Boolean) {
+            palmRejectionEnabled = enabled
+        }
+
+        private fun detectThreeFingerTap(event: MotionEvent) {
+            val action = event.actionMasked
+            if (action == MotionEvent.ACTION_POINTER_DOWN && event.pointerCount == 3) {
+                threeFingerTapDownTime = System.currentTimeMillis()
+                isThreeFingerTapCheck = true
+                // Cancel any pending two-finger tap so 3 fingers don't also trigger undo.
+                isTwoFingerTapCheck = false
+                for (i in 0 until 3) {
+                    threeFingerPointerIds[i] = event.getPointerId(i)
+                    threeFingerStartPts[i][0] = event.getX(i)
+                    threeFingerStartPts[i][1] = event.getY(i)
+                }
+            } else if (action == MotionEvent.ACTION_POINTER_UP && event.pointerCount == 3) {
+                if (isThreeFingerTapCheck) {
+                    val duration = System.currentTimeMillis() - threeFingerTapDownTime
+                    if (duration < CanvasConfig.TWO_FINGER_TAP_MAX_DELAY && !isThreeTapSlopExceeded(event)) {
+                        onThreeFingerTap?.invoke()
+                    }
+                    isThreeFingerTapCheck = false
+                }
+            } else if (action == MotionEvent.ACTION_MOVE && isThreeFingerTapCheck) {
+                if (event.pointerCount == 3) {
+                    if (isThreeTapSlopExceeded(event)) {
+                        isThreeFingerTapCheck = false
+                    }
+                } else {
+                    isThreeFingerTapCheck = false
+                }
+            } else if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
+                isThreeFingerTapCheck = false
+            }
+        }
+
+        private fun isThreeTapSlopExceeded(event: MotionEvent): Boolean {
+            for (i in 0 until 3) {
+                val index = event.findPointerIndex(threeFingerPointerIds[i])
+                if (index == -1) return true
+                val d = distSq(event.getX(index), event.getY(index), threeFingerStartPts[i][0], threeFingerStartPts[i][1])
+                if (d > CanvasConfig.TWO_FINGER_TAP_SLOP_SQ) return true
+            }
+            return false
+        }
 
         override fun onGenericMotionEvent(event: MotionEvent): Boolean {
             when (event.actionMasked) {

--- a/app/src/main/java/com/alexdremov/notate/ui/OnyxCanvasView.kt
+++ b/app/src/main/java/com/alexdremov/notate/ui/OnyxCanvasView.kt
@@ -21,8 +21,10 @@ import com.alexdremov.notate.data.PreferencesManager
 import com.alexdremov.notate.model.InfiniteCanvasModel
 import com.alexdremov.notate.model.PenTool
 import com.alexdremov.notate.model.Stroke
+import com.alexdremov.notate.model.StylusButtonAction
 import com.alexdremov.notate.model.TextItem
 import com.alexdremov.notate.model.ToolType
+import com.alexdremov.notate.model.TwoFingerTapAction
 import com.alexdremov.notate.ui.controller.CanvasControllerImpl
 import com.alexdremov.notate.ui.controller.ViewportController
 import com.alexdremov.notate.ui.input.PenInputHandler
@@ -120,6 +122,12 @@ class OnyxCanvasView
         private var isThreeFingerTapCheck = false
         private val threeFingerStartPts = Array(3) { floatArrayOf(0f, 0f) }
         private val threeFingerPointerIds = intArrayOf(-1, -1, -1)
+
+        @Volatile
+        private var twoFingerTapAction: TwoFingerTapAction = PreferencesManager.getTwoFingerTapAction(context)
+
+        @Volatile
+        private var stylusButtonAction: StylusButtonAction = PreferencesManager.getStylusButtonAction(context)
 
         private var lastStrokeEndTime = 0L
 
@@ -473,7 +481,22 @@ class OnyxCanvasView
                     if (duration < CanvasConfig.TWO_FINGER_TAP_MAX_DELAY) {
                         if (!isTapSlopExceeded(event)) {
                             if (now - lastTwoFingerTapTime < CanvasConfig.TWO_FINGER_TAP_DOUBLE_TIMEOUT) {
-                                viewScope.launch { undo() }
+                                when (twoFingerTapAction) {
+                                    TwoFingerTapAction.UNDO -> viewScope.launch { undo() }
+                                    TwoFingerTapAction.REDO -> viewScope.launch { redo() }
+                                    TwoFingerTapAction.PASTE -> {
+                                        val inv = Matrix()
+                                        matrix.invert(inv)
+                                        val pts =
+                                            floatArrayOf(
+                                                (twoFingerStartPt1[0] + twoFingerStartPt2[0]) / 2f,
+                                                (twoFingerStartPt1[1] + twoFingerStartPt2[1]) / 2f,
+                                            )
+                                        inv.mapPoints(pts)
+                                        viewScope.launch { canvasController.paste(pts[0], pts[1]) }
+                                    }
+                                    TwoFingerTapAction.NONE -> {}
+                                }
                                 lastTwoFingerTapTime = 0L
                             } else {
                                 lastTwoFingerTapTime = now
@@ -565,7 +588,8 @@ class OnyxCanvasView
                 MotionEvent.ACTION_HOVER_MOVE -> {
                     val toolType = event.getToolType(0)
                     val isEraserTail = toolType == MotionEvent.TOOL_TYPE_ERASER
-                    val isStylusButton = (event.buttonState and MotionEvent.BUTTON_STYLUS_PRIMARY) != 0
+                    val isStylusButton = (event.buttonState and MotionEvent.BUTTON_STYLUS_PRIMARY) != 0 &&
+                        stylusButtonAction == StylusButtonAction.TEMPORARY_ERASER
                     if (isEraserTail || isStylusButton) penInputHandler.prepareEraser() else penInputHandler.finishEraser()
                     penInputHandler.onHoverMove(event)
                 }
@@ -788,6 +812,14 @@ class OnyxCanvasView
 
         fun setCursorView(view: CursorView) {
             penInputHandler.setCursorView(view)
+        }
+
+        fun setTwoFingerTapAction(action: TwoFingerTapAction) {
+            twoFingerTapAction = action
+        }
+
+        fun setStylusButtonAction(action: StylusButtonAction) {
+            stylusButtonAction = action
         }
 
         suspend fun setBackgroundStyle(style: com.alexdremov.notate.model.BackgroundStyle) {

--- a/app/src/main/java/com/alexdremov/notate/ui/SettingsSidebarController.kt
+++ b/app/src/main/java/com/alexdremov/notate/ui/SettingsSidebarController.kt
@@ -27,6 +27,7 @@ import com.alexdremov.notate.ui.settings.InputSettingsPanel
 import com.alexdremov.notate.ui.settings.InputSettingsState
 import com.alexdremov.notate.ui.settings.InterfaceSettingsPanel
 import com.alexdremov.notate.ui.settings.InterfaceSettingsState
+import com.alexdremov.notate.ui.settings.SettingsToggle
 import com.alexdremov.notate.ui.theme.NotateTheme
 import com.alexdremov.notate.vm.DrawingViewModel
 import kotlin.math.roundToInt
@@ -41,6 +42,7 @@ class SettingsSidebarController(
     private val onExportRequest: (ExportAction) -> Unit,
     private val onEditToolbar: () -> Unit,
     private val onGeneratePatterns: (com.alexdremov.notate.util.PatternGenerator.PatternType, Float) -> Unit,
+    private val onPalmRejectionChanged: (Boolean) -> Unit,
 ) {
     private val wrapperView: View = LayoutInflater.from(context).inflate(R.layout.sidebar_layout_wrapper, container, false)
     private val contentFrame: FrameLayout = wrapperView.findViewById(R.id.sidebar_content)
@@ -219,12 +221,26 @@ class SettingsSidebarController(
                                             )
                                     }
 
+                                val (localPalm, setLocalPalm) =
+                                    androidx.compose.runtime.remember {
+                                        androidx.compose.runtime.mutableStateOf(
+                                            com.alexdremov.notate.data.PreferencesManager
+                                                .isPalmRejectionEnabled(context),
+                                        )
+                                    }
+
                                 InputSettingsPanel(
-                                    state = InputSettingsState(localScribble, localShape, localAngle, localAxis, localShapeDelay),
+                                    state = InputSettingsState(localScribble, localShape, localAngle, localAxis, localShapeDelay, localPalm),
                                     onScribbleChange = {
                                         setScribble(it)
                                         com.alexdremov.notate.data.PreferencesManager
                                             .setScribbleToEraseEnabled(context, it)
+                                    },
+                                    onPalmRejectionChange = {
+                                        setLocalPalm(it)
+                                        com.alexdremov.notate.data.PreferencesManager
+                                            .setPalmRejectionEnabled(context, it)
+                                        onPalmRejectionChanged(it)
                                     },
                                     onShapeChange = {
                                         setShape(it)
@@ -264,6 +280,17 @@ class SettingsSidebarController(
                                     onCollapsibleChange = { viewModel.setCollapsibleToolbar(it) },
                                     onTimeoutChange = { setLocalTimeout(it) },
                                     onTimeoutFinished = { viewModel.setToolbarCollapseTimeout(localTimeout.toLong()) },
+                                )
+
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(vertical = 16.dp),
+                                )
+
+                                val distractionFree by viewModel.isDistractionFree.collectAsState()
+                                SettingsToggle(
+                                    title = "Distraction-free mode",
+                                    checked = distractionFree,
+                                    onCheckedChange = { viewModel.setDistractionFree(it) },
                                 )
                             }
                         }

--- a/app/src/main/java/com/alexdremov/notate/ui/SettingsSidebarController.kt
+++ b/app/src/main/java/com/alexdremov/notate/ui/SettingsSidebarController.kt
@@ -43,6 +43,8 @@ class SettingsSidebarController(
     private val onEditToolbar: () -> Unit,
     private val onGeneratePatterns: (com.alexdremov.notate.util.PatternGenerator.PatternType, Float) -> Unit,
     private val onPalmRejectionChanged: (Boolean) -> Unit,
+    private val onTwoFingerTapActionChange: (com.alexdremov.notate.model.TwoFingerTapAction) -> Unit,
+    private val onStylusButtonActionChange: (com.alexdremov.notate.model.StylusButtonAction) -> Unit,
 ) {
     private val wrapperView: View = LayoutInflater.from(context).inflate(R.layout.sidebar_layout_wrapper, container, false)
     private val contentFrame: FrameLayout = wrapperView.findViewById(R.id.sidebar_content)
@@ -220,6 +222,20 @@ class SettingsSidebarController(
                                                 shapeDelay,
                                             )
                                     }
+                                val (localTapAction, setTapAction) =
+                                    androidx.compose.runtime.remember {
+                                        androidx.compose.runtime.mutableStateOf(
+                                            com.alexdremov.notate.data.PreferencesManager
+                                                .getTwoFingerTapAction(context),
+                                        )
+                                    }
+                                val (localButtonAction, setButtonAction) =
+                                    androidx.compose.runtime.remember {
+                                        androidx.compose.runtime.mutableStateOf(
+                                            com.alexdremov.notate.data.PreferencesManager
+                                                .getStylusButtonAction(context),
+                                        )
+                                    }
 
                                 val (localPalm, setLocalPalm) =
                                     androidx.compose.runtime.remember {
@@ -230,7 +246,17 @@ class SettingsSidebarController(
                                     }
 
                                 InputSettingsPanel(
-                                    state = InputSettingsState(localScribble, localShape, localAngle, localAxis, localShapeDelay, localPalm),
+                                    state =
+                                        InputSettingsState(
+                                            localScribble,
+                                            localShape,
+                                            localAngle,
+                                            localAxis,
+                                            localShapeDelay,
+                                            localPalm,
+                                            localTapAction,
+                                            localButtonAction,
+                                        ),
                                     onScribbleChange = {
                                         setScribble(it)
                                         com.alexdremov.notate.data.PreferencesManager
@@ -263,6 +289,18 @@ class SettingsSidebarController(
                                             context,
                                             localShapeDelay.toLong(),
                                         )
+                                    },
+                                    onTwoFingerTapChange = {
+                                        setTapAction(it)
+                                        com.alexdremov.notate.data.PreferencesManager
+                                            .setTwoFingerTapAction(context, it)
+                                        onTwoFingerTapActionChange(it)
+                                    },
+                                    onStylusButtonChange = {
+                                        setButtonAction(it)
+                                        com.alexdremov.notate.data.PreferencesManager
+                                            .setStylusButtonAction(context, it)
+                                        onStylusButtonActionChange(it)
                                     },
                                 )
 

--- a/app/src/main/java/com/alexdremov/notate/ui/home/FileBrowserScreen.kt
+++ b/app/src/main/java/com/alexdremov/notate/ui/home/FileBrowserScreen.kt
@@ -4,6 +4,7 @@ package com.alexdremov.notate.ui.home
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -13,9 +14,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items as recentItems
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilterChip
@@ -59,6 +63,9 @@ fun FileBrowserScreen(
     onItemRename: (FileSystemItem, String) -> Unit,
     onItemDuplicate: (FileSystemItem) -> Unit,
     onSetFileTags: (FileSystemItem, List<String>) -> Unit = { _, _ -> },
+    favorites: Set<String> = emptySet(),
+    recents: List<CanvasItem> = emptyList(),
+    onToggleFavorite: (FileSystemItem) -> Unit = {},
 ) {
     var itemToDelete by remember { mutableStateOf<FileSystemItem?>(null) }
     var managingItemPath by remember { mutableStateOf<String?>(null) }
@@ -70,6 +77,31 @@ fun FileBrowserScreen(
             onItemClick = onBreadcrumbClick,
             modifier = Modifier.fillMaxWidth(),
         )
+
+        val atRoot = breadcrumbs.size <= 1
+        if (recents.isNotEmpty() && atRoot) {
+            Text(
+                text = "Recent",
+                style = MaterialTheme.typography.titleSmall,
+                modifier = Modifier.padding(start = 16.dp, top = 8.dp),
+            )
+            LazyRow(
+                contentPadding = PaddingValues(horizontal = 8.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                recentItems(recents) { recent ->
+                    Box(modifier = Modifier.width(160.dp)) {
+                        FileGridItem(
+                            item = recent,
+                            isFavorite = favorites.contains(recent.uuid ?: recent.path),
+                            onClick = { onItemClick(recent) },
+                            onLongClick = { if (!isReadOnly) managingItemPath = recent.path },
+                        )
+                    }
+                }
+            }
+            HorizontalDivider()
+        }
 
         if (items.isEmpty()) {
             EmptyState("Folder is empty.\nCreate a folder or canvas.")
@@ -90,6 +122,7 @@ fun FileBrowserScreen(
                     FileGridItem(
                         item = it,
                         enabled = isEnabled,
+                        isFavorite = it is CanvasItem && favorites.contains(it.uuid ?: it.path),
                         onClick = { onItemClick(it) },
                         onLongClick = {
                             if (isEnabled && !isReadOnly) managingItemPath = it.path
@@ -101,7 +134,7 @@ fun FileBrowserScreen(
     }
 
     // Context Menu / Options Dialog
-    val currentItem = if (managingItemPath != null) items.find { it.path == managingItemPath } else null
+    val currentItem = if (managingItemPath != null) (items + recents).find { it.path == managingItemPath } else null
 
     if (currentItem != null) {
         AlertDialog(
@@ -148,6 +181,20 @@ fun FileBrowserScreen(
                         modifier = Modifier.fillMaxWidth(),
                     ) {
                         Text("Delete", color = Color.Red)
+                    }
+
+                    if (currentItem is CanvasItem) {
+                        val isFav = favorites.contains(currentItem.uuid ?: currentItem.path)
+                        Spacer(modifier = Modifier.height(8.dp))
+                        OutlinedButton(
+                            onClick = {
+                                onToggleFavorite(currentItem)
+                                managingItemPath = null
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text(if (isFav) "★ Unfavorite" else "☆ Favorite", color = Color.Black)
+                        }
                     }
 
                     if (currentItem is CanvasItem && allTags.isNotEmpty()) {

--- a/app/src/main/java/com/alexdremov/notate/ui/home/SettingsDialog.kt
+++ b/app/src/main/java/com/alexdremov/notate/ui/home/SettingsDialog.kt
@@ -56,6 +56,7 @@ import com.alexdremov.notate.ui.settings.InterfaceSettingsPanel
 import com.alexdremov.notate.ui.settings.InterfaceSettingsState
 import com.alexdremov.notate.ui.settings.PdfSettingsPanel
 import com.alexdremov.notate.ui.settings.PdfSettingsState
+import com.alexdremov.notate.ui.settings.SettingsToggle
 
 @Composable
 fun SettingsDialog(
@@ -147,12 +148,17 @@ fun SettingsDialog(
                         var angleSnapping by remember { mutableStateOf(PreferencesManager.isAngleSnappingEnabled(context)) }
                         var axisLocking by remember { mutableStateOf(PreferencesManager.isAxisLockingEnabled(context)) }
                         var shapeDelay by remember { mutableFloatStateOf(PreferencesManager.getShapePerfectionDelay(context).toFloat()) }
+                        var palmRejection by remember { mutableStateOf(PreferencesManager.isPalmRejectionEnabled(context)) }
 
                         InputSettingsPanel(
-                            state = InputSettingsState(scribbleEnabled, shapeEnabled, angleSnapping, axisLocking, shapeDelay),
+                            state = InputSettingsState(scribbleEnabled, shapeEnabled, angleSnapping, axisLocking, shapeDelay, palmRejection),
                             onScribbleChange = {
                                 scribbleEnabled = it
                                 PreferencesManager.setScribbleToEraseEnabled(context, it)
+                            },
+                            onPalmRejectionChange = {
+                                palmRejection = it
+                                PreferencesManager.setPalmRejectionEnabled(context, it)
                             },
                             onShapeChange = {
                                 shapeEnabled = it
@@ -175,6 +181,7 @@ fun SettingsDialog(
 
                     SettingsScreen.INTERFACE -> {
                         var collapsibleToolbar by remember { mutableStateOf(PreferencesManager.isCollapsibleToolbarEnabled(context)) }
+                        var openDailyOnStart by remember { mutableStateOf(PreferencesManager.isOpenDailyOnStartEnabled(context)) }
                         var collapseTimeout by remember {
                             mutableFloatStateOf(
                                 PreferencesManager.getToolbarCollapseTimeout(context).toFloat(),
@@ -190,6 +197,16 @@ fun SettingsDialog(
                             onTimeoutChange = { collapseTimeout = it },
                             onTimeoutFinished = {
                                 PreferencesManager.setToolbarCollapseTimeout(context, collapseTimeout.toLong())
+                            },
+                        )
+
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                        SettingsToggle(
+                            title = "Open daily note on startup",
+                            checked = openDailyOnStart,
+                            onCheckedChange = {
+                                openDailyOnStart = it
+                                PreferencesManager.setOpenDailyOnStartEnabled(context, it)
                             },
                         )
                     }

--- a/app/src/main/java/com/alexdremov/notate/ui/home/SettingsDialog.kt
+++ b/app/src/main/java/com/alexdremov/notate/ui/home/SettingsDialog.kt
@@ -149,9 +149,21 @@ fun SettingsDialog(
                         var axisLocking by remember { mutableStateOf(PreferencesManager.isAxisLockingEnabled(context)) }
                         var shapeDelay by remember { mutableFloatStateOf(PreferencesManager.getShapePerfectionDelay(context).toFloat()) }
                         var palmRejection by remember { mutableStateOf(PreferencesManager.isPalmRejectionEnabled(context)) }
+                        var twoFingerTapAction by remember { mutableStateOf(PreferencesManager.getTwoFingerTapAction(context)) }
+                        var stylusButtonAction by remember { mutableStateOf(PreferencesManager.getStylusButtonAction(context)) }
 
                         InputSettingsPanel(
-                            state = InputSettingsState(scribbleEnabled, shapeEnabled, angleSnapping, axisLocking, shapeDelay, palmRejection),
+                            state =
+                                InputSettingsState(
+                                    scribbleEnabled,
+                                    shapeEnabled,
+                                    angleSnapping,
+                                    axisLocking,
+                                    shapeDelay,
+                                    palmRejection,
+                                    twoFingerTapAction,
+                                    stylusButtonAction,
+                                ),
                             onScribbleChange = {
                                 scribbleEnabled = it
                                 PreferencesManager.setScribbleToEraseEnabled(context, it)
@@ -175,6 +187,14 @@ fun SettingsDialog(
                             onShapeDelayChange = { shapeDelay = it },
                             onShapeDelayFinished = {
                                 PreferencesManager.setShapePerfectionDelay(context, shapeDelay.toLong())
+                            },
+                            onTwoFingerTapChange = {
+                                twoFingerTapAction = it
+                                PreferencesManager.setTwoFingerTapAction(context, it)
+                            },
+                            onStylusButtonChange = {
+                                stylusButtonAction = it
+                                PreferencesManager.setStylusButtonAction(context, it)
                             },
                         )
                     }

--- a/app/src/main/java/com/alexdremov/notate/ui/home/Sidebar.kt
+++ b/app/src/main/java/com/alexdremov/notate/ui/home/Sidebar.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Circle
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Today
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -52,6 +53,7 @@ fun Sidebar(
     onAddProject: () -> Unit,
     onManageTags: () -> Unit,
     onSettingsClick: () -> Unit,
+    onTodayClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Surface(
@@ -129,6 +131,12 @@ fun Sidebar(
 
             // Bottom Settings Area
             HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+            SidebarItem(
+                text = "Today",
+                icon = Icons.Default.Today,
+                isSelected = false,
+                onClick = onTodayClick,
+            )
             SidebarItem(
                 text = "Settings",
                 icon = Icons.Default.Settings,

--- a/app/src/main/java/com/alexdremov/notate/ui/home/components/FileGridItem.kt
+++ b/app/src/main/java/com/alexdremov/notate/ui/home/components/FileGridItem.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -41,6 +42,7 @@ fun FileGridItem(
     onClick: () -> Unit,
     onLongClick: () -> Unit,
     enabled: Boolean = true,
+    isFavorite: Boolean = false,
 ) {
     Card(
         modifier =
@@ -138,6 +140,25 @@ fun FileGridItem(
                             contentDescription = "Syncing",
                             tint = if (item.syncStatus == SyncStatus.SYNCING) Color(0xFF007AFF) else Color.Gray,
                             modifier = Modifier.fillMaxSize().rotate(angle),
+                        )
+                    }
+                }
+
+                if (isFavorite) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .align(Alignment.TopStart)
+                                .padding(8.dp)
+                                .size(24.dp)
+                                .background(Color.White.copy(alpha = 0.8f), androidx.compose.foundation.shape.CircleShape)
+                                .padding(2.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Star,
+                            contentDescription = "Favorite",
+                            tint = Color(0xFFFFB300),
+                            modifier = Modifier.fillMaxSize(),
                         )
                     }
                 }

--- a/app/src/main/java/com/alexdremov/notate/ui/settings/SettingsPanels.kt
+++ b/app/src/main/java/com/alexdremov/notate/ui/settings/SettingsPanels.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.alexdremov.notate.model.StylusButtonAction
+import com.alexdremov.notate.model.TwoFingerTapAction
 
 data class InputSettingsState(
     val scribbleEnabled: Boolean,
@@ -28,6 +30,8 @@ data class InputSettingsState(
     val axisLocking: Boolean,
     val shapeDelay: Float,
     val palmRejection: Boolean,
+    val twoFingerTapAction: TwoFingerTapAction,
+    val stylusButtonAction: StylusButtonAction,
 )
 
 data class InterfaceSettingsState(
@@ -45,6 +49,8 @@ fun InputSettingsPanel(
     onAxisChange: (Boolean) -> Unit,
     onShapeDelayChange: (Float) -> Unit,
     onShapeDelayFinished: () -> Unit,
+    onTwoFingerTapChange: (TwoFingerTapAction) -> Unit,
+    onStylusButtonChange: (StylusButtonAction) -> Unit,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
         SettingsToggle(
@@ -98,6 +104,32 @@ fun InputSettingsPanel(
             title = "Axis Locking",
             checked = state.axisLocking,
             onCheckedChange = onAxisChange,
+        )
+
+        HorizontalDivider()
+        SettingsRadioGroup(
+            title = "Two-finger tap",
+            options =
+                listOf(
+                    TwoFingerTapAction.UNDO to "Undo",
+                    TwoFingerTapAction.REDO to "Redo",
+                    TwoFingerTapAction.PASTE to "Paste",
+                    TwoFingerTapAction.NONE to "None",
+                ),
+            selected = state.twoFingerTapAction,
+            onSelect = onTwoFingerTapChange,
+        )
+
+        HorizontalDivider()
+        SettingsRadioGroup(
+            title = "Stylus side button",
+            options =
+                listOf(
+                    StylusButtonAction.TEMPORARY_ERASER to "Temporary eraser",
+                    StylusButtonAction.NONE to "Off",
+                ),
+            selected = state.stylusButtonAction,
+            onSelect = onStylusButtonChange,
         )
     }
 }
@@ -158,6 +190,36 @@ fun SettingsToggle(
             checked = checked,
             onCheckedChange = onCheckedChange,
         )
+    }
+}
+
+@Composable
+private fun <T> SettingsRadioGroup(
+    title: String,
+    options: List<Pair<T, String>>,
+    selected: T,
+    onSelect: (T) -> Unit,
+) {
+    Column {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        options.forEach { (value, label) ->
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clickable { onSelect(value) },
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                RadioButton(
+                    selected = selected == value,
+                    onClick = { onSelect(value) },
+                )
+                Text(label)
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/alexdremov/notate/ui/settings/SettingsPanels.kt
+++ b/app/src/main/java/com/alexdremov/notate/ui/settings/SettingsPanels.kt
@@ -27,6 +27,7 @@ data class InputSettingsState(
     val angleSnapping: Boolean,
     val axisLocking: Boolean,
     val shapeDelay: Float,
+    val palmRejection: Boolean,
 )
 
 data class InterfaceSettingsState(
@@ -38,6 +39,7 @@ data class InterfaceSettingsState(
 fun InputSettingsPanel(
     state: InputSettingsState,
     onScribbleChange: (Boolean) -> Unit,
+    onPalmRejectionChange: (Boolean) -> Unit,
     onShapeChange: (Boolean) -> Unit,
     onAngleChange: (Boolean) -> Unit,
     onAxisChange: (Boolean) -> Unit,
@@ -49,6 +51,13 @@ fun InputSettingsPanel(
             title = "Scribble to Erase",
             checked = state.scribbleEnabled,
             onCheckedChange = onScribbleChange,
+        )
+        HorizontalDivider()
+
+        SettingsToggle(
+            title = "Palm Rejection (stylus only)",
+            checked = state.palmRejection,
+            onCheckedChange = onPalmRejectionChange,
         )
         HorizontalDivider()
 

--- a/app/src/main/java/com/alexdremov/notate/vm/DrawingViewModel.kt
+++ b/app/src/main/java/com/alexdremov/notate/vm/DrawingViewModel.kt
@@ -78,6 +78,9 @@ class DrawingViewModel
         private val _isCollapsibleToolbar = MutableStateFlow(false)
         val isCollapsibleToolbar: StateFlow<Boolean> = _isCollapsibleToolbar.asStateFlow()
 
+        private val _isDistractionFree = MutableStateFlow(false)
+        val isDistractionFree: StateFlow<Boolean> = _isDistractionFree.asStateFlow()
+
         private val _isToolbarCollapsed = MutableStateFlow(false)
         val isToolbarCollapsed: StateFlow<Boolean> = _isToolbarCollapsed.asStateFlow()
 
@@ -95,6 +98,7 @@ class DrawingViewModel
             _isCollapsibleToolbar.value = PreferencesManager.isCollapsibleToolbarEnabled(getApplication())
             _toolbarCollapseTimeout.value = PreferencesManager.getToolbarCollapseTimeout(getApplication())
             _isFixedPageCenterHorizontal.value = PreferencesManager.isFixedPageCenterHorizontalEnabled(getApplication())
+            _isDistractionFree.value = PreferencesManager.isDistractionFreeEnabled(getApplication())
         }
 
         suspend fun loadCanvasSession(path: String) {
@@ -266,6 +270,15 @@ class DrawingViewModel
 
         fun setToolbarCollapsed(collapsed: Boolean) {
             _isToolbarCollapsed.value = collapsed
+        }
+
+        fun setDistractionFree(enabled: Boolean) {
+            _isDistractionFree.value = enabled
+            PreferencesManager.setDistractionFreeEnabled(getApplication(), enabled)
+        }
+
+        fun toggleDistractionFree() {
+            setDistractionFree(!_isDistractionFree.value)
         }
 
         fun setToolbarDragging(dragging: Boolean) {

--- a/app/src/main/java/com/alexdremov/notate/vm/HomeViewModel.kt
+++ b/app/src/main/java/com/alexdremov/notate/vm/HomeViewModel.kt
@@ -72,6 +72,12 @@ class HomeViewModel(
     private val _savingPaths = MutableStateFlow<Set<String>>(emptySet())
     val savingPaths: StateFlow<Set<String>> = _savingPaths.asStateFlow()
 
+    private val _favorites = MutableStateFlow<Set<String>>(emptySet())
+    val favorites: StateFlow<Set<String>> = _favorites.asStateFlow()
+
+    private val _recents = MutableStateFlow<List<CanvasItem>>(emptyList())
+    val recents: StateFlow<List<CanvasItem>> = _recents.asStateFlow()
+
     init {
         loadProjects()
         loadTags()
@@ -79,6 +85,46 @@ class HomeViewModel(
         startIndexing()
         observeSaveStatus()
         observeGlobalSync()
+        loadFavorites()
+    }
+
+    private fun loadFavorites() {
+        _favorites.value = PreferencesManager.getFavorites(getApplication())
+    }
+
+    fun toggleFavorite(item: FileSystemItem) {
+        if (item !is CanvasItem) return
+        val key = item.uuid ?: item.path
+        val newFav = !_favorites.value.contains(key)
+        _favorites.value = if (newFav) _favorites.value + key else _favorites.value - key
+        PreferencesManager.setFavorite(getApplication(), key, newFav)
+    }
+
+    private fun loadRecents() {
+        val repo = repository
+        val path = _currentPath.value
+        val atRoot = repo != null && (path == null || path == repo.getRootPath())
+        if (repo == null || !atRoot) {
+            _recents.value = emptyList()
+            return
+        }
+        viewModelScope.launch {
+            val resolved =
+                withContext(Dispatchers.IO) {
+                    val keys = PreferencesManager.getRecents(getApplication())
+                    if (keys.isEmpty()) return@withContext emptyList<CanvasItem>()
+                    val indexed =
+                        try {
+                            repo.getAllIndexedFiles()
+                        } catch (e: Exception) {
+                            emptyList<CanvasItem>()
+                        }
+                    val byUuid = indexed.mapNotNull { c -> c.uuid?.let { it to c } }.toMap()
+                    val byPath = indexed.associateBy { it.path }
+                    keys.mapNotNull { key -> byUuid[key] ?: byPath[key] }
+                }
+            _recents.value = resolved
+        }
     }
 
     private fun observeSaveStatus() {
@@ -519,6 +565,7 @@ class HomeViewModel(
         _currentPath.value = path
         updateTitle()
         updateBreadcrumbs()
+        loadRecents()
         viewModelScope.launch {
             val items =
                 withContext(Dispatchers.IO) {
@@ -741,6 +788,7 @@ class HomeViewModel(
     }
 
     fun refresh() {
+        loadFavorites()
         val repo = repository
         val tag = _selectedTag.value
 


### PR DESCRIPTION
## Summary

- add palm rejection controls and a three-finger distraction-free gesture
- add daily-note startup/navigation plus favorites and recent-file access
- make two-finger double-tap configurable as Undo, Redo, Paste, or None
- make the stylus side button configurable as a temporary eraser or Off
- persist input preferences and apply sidebar changes to the active canvas immediately

## Why

These changes streamline common e-ink note-taking workflows and let users adapt gesture and stylus behavior to their device and preferences.

## User impact

Users can reach frequently used notes faster, reduce interface distractions while writing, reject unintended touch input, and choose how key canvas gestures behave.

## Validation

- `./gradlew :app:compileDebugKotlin`
